### PR TITLE
Notion auth supports OpenClaw SecretRef injection

### DIFF
--- a/diy-pc-ingest/README.md
+++ b/diy-pc-ingest/README.md
@@ -6,7 +6,7 @@ Discordなどに貼り付けたPCパーツ購入ログ/メモを、OpenClaw経�
 - 迷うところは止めて質問、確実なところは即時反映
 - Notion APIは **2025-09-03**(data_sources世代)前提
 
-> このリポジトリには個人のNotion IDやAPIキーは含めません。各自の環境のに設定してください。
+> このリポジトリには個人のNotion IDやAPIキーは含めません。各自の環境に設定してください。
 
 ---
 
@@ -134,13 +134,29 @@ clawhub install notion-api-automation
 
 ### 2) トークン(APIキー)を用意
 
-環境変数で渡す
+従来どおり環境変数で渡せます。
 
 ```bash
 export NOTION_API_KEY="<your notion token>"
 ```
 
-OpenClawでは `~/.openclaw/.env` に書いて起動時に環境変数として読ませる
+OpenClawでは `skills.entries["diy-pc-ingest"].apiKey` に設定する方法も使えます。
+`apiKey` はこのskillの `primaryEnv` である `NOTION_API_KEY` として実行時に注入されます。
+SecretRef provider はユーザー環境ごとに異なるため、このskillには特定のvault/item/pathを固定しません。
+
+```json5
+{
+  skills: {
+    entries: {
+      "diy-pc-ingest": {
+        apiKey: { source: "exec", provider: "your_notion_secret_provider", id: "value" }
+      }
+    }
+  }
+}
+```
+
+`source` は `env` / `file` / `exec` など、OpenClaw Gatewayで設定済みのSecretRef providerに合わせてください。
 
 ### 3) NotionのIDを自動検出して設定(推奨)
 
@@ -150,7 +166,7 @@ Notionの `data_source_id` / `database_id` は、Integrationがアクセスで�
 ```bash
 cd skills/diy-pc-ingest
 
-# NOTION_API_KEY を設定した状態で実行
+# NOTION_API_KEY env、またはOpenClaw apiKey SecretRef注入が有効な状態で実行
 node scripts/bootstrap_config.js
 ```
 

--- a/diy-pc-ingest/SKILL.md
+++ b/diy-pc-ingest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: diy-pc-ingest
 description: Ingest pasted PC parts purchase/config text (Discord message receipts, bullet lists) into Notion DIY_PC tables (PCConfig, ストレージ, エンクロージャー, PCInput). Use when the user pastes raw purchase logs/spec notes and wants the AI to classify, enrich via web search, ask follow-up questions for unknowns, and then upsert rows into the correct Notion data sources using the 2025-09-03 data_sources API.
-metadata: {"openclaw":{"requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"optionalEnv":["NOTION_TOKEN","NOTION_API_KEY_FILE","NOTION_VERSION"],"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"network":["notion-api","optional:web_search/web_fetch"]}}
+metadata: {"openclaw":{"requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"optionalEnv":["NOTION_TOKEN","NOTION_API_TOKEN","NOTION_API_KEY_FILE","NOTION_VERSION","NOTIONCTL_PATH"],"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"network":["notion-api","optional:web_search/web_fetch"]}}
 ---
 
 # diy-pc-ingest
@@ -23,10 +23,32 @@ clawhub install notion-api-automation
 - `--enclosure-dsid`, `--enclosure-dbid`
 
 2) Provide Notion auth for `notion-api-automation` (`notionctl`):
-- env: `NOTION_API_KEY` (recommended)
+- env: `NOTION_API_KEY` (legacy shell/service env remains supported)
+- OpenClaw config: `skills.entries["diy-pc-ingest"].apiKey`
+
+`apiKey` is associated with `metadata.openclaw.primaryEnv` and is injected as
+`NOTION_API_KEY` for the host agent run. It may be a plaintext value or any
+OpenClaw SecretRef supported by the local gateway (`env`, `file`, `exec`, etc.).
+Do not hardcode provider-specific secret paths in this shared skill.
+
+Example SecretRef shape:
+
+```json5
+{
+  skills: {
+    entries: {
+      "diy-pc-ingest": {
+        apiKey: { source: "exec", provider: "your_notion_secret_provider", id: "value" }
+      }
+    }
+  }
+}
+```
 
 Notes:
 - This skill uses Notion-Version `2025-09-03` by default.
+- If `NOTIONCTL_PATH` is set, `scripts/notion_apply_records.js` uses that
+  notionctl path; otherwise it uses the sibling `notion-api-automation` skill.
 
 ## Data flow disclosure
 

--- a/diy-pc-ingest/scripts/notion_apply_records.js
+++ b/diy-pc-ingest/scripts/notion_apply_records.js
@@ -22,7 +22,8 @@ const path = require('path');
 const { execFileSync } = require('node:child_process');
 
 const DEFAULT_NOTION_VERSION = '2025-09-03';
-const NOTIONCTL_PATH = path.resolve(__dirname, '..', '..', 'notion-api-automation', 'scripts', 'notionctl.mjs');
+const DEFAULT_NOTIONCTL_PATH = path.resolve(__dirname, '..', '..', 'notion-api-automation', 'scripts', 'notionctl.mjs');
+const NOTION_AUTH_ENV_KEYS = ['NOTION_API_KEY', 'NOTION_TOKEN', 'NOTION_API_TOKEN', 'NOTION_API_KEY_FILE'];
 
 function die(msg) {
   process.stderr.write(String(msg) + '\n');
@@ -67,6 +68,28 @@ function notionVersion() {
   return (process.env.NOTION_VERSION || DEFAULT_NOTION_VERSION).trim();
 }
 
+function notionctlPath() {
+  return process.env.NOTIONCTL_PATH || DEFAULT_NOTIONCTL_PATH;
+}
+
+function redactKnownSecrets(text) {
+  let out = String(text || '');
+  for (const k of NOTION_AUTH_ENV_KEYS) {
+    const value = process.env[k];
+    if (!value || k.endsWith('_FILE')) continue;
+    out = out.split(String(value)).join(`[redacted:${k}]`);
+  }
+  return out;
+}
+
+function authSetupHint() {
+  return [
+    'Configure Notion auth with NOTION_API_KEY/NOTION_TOKEN,',
+    'or set skills.entries["diy-pc-ingest"].apiKey to an OpenClaw SecretRef.',
+    'The SecretRef provider can be env, file, exec, or another OpenClaw-supported secure provider.',
+  ].join(' ');
+}
+
 function safeEnv(extra = {}) {
   const env = {
     PATH: process.env.PATH || '',
@@ -77,16 +100,17 @@ function safeEnv(extra = {}) {
     SYSTEMROOT: process.env.SYSTEMROOT || '',
     WINDIR: process.env.WINDIR || '',
   };
-  for (const k of ['NOTION_API_KEY', 'NOTION_TOKEN', 'NOTION_API_KEY_FILE']) {
+  for (const k of NOTION_AUTH_ENV_KEYS) {
     if (process.env[k]) env[k] = process.env[k];
   }
+  if (process.env.NOTIONCTL_PATH) env.NOTIONCTL_PATH = process.env.NOTIONCTL_PATH;
   return { ...env, ...extra };
 }
 
 async function notionReq(method, apiPath, body) {
   const p = String(apiPath).startsWith('/v1/') ? String(apiPath) : `/v1${String(apiPath).startsWith('/') ? '' : '/'}${String(apiPath)}`;
   const args = [
-    NOTIONCTL_PATH,
+    notionctlPath(),
     'api',
     '--compact',
     '--method', String(method).toUpperCase(),
@@ -96,9 +120,18 @@ async function notionReq(method, apiPath, body) {
 
   const env = safeEnv({ NOTION_VERSION: notionVersion() });
 
-  const out = execFileSync('node', args, { encoding: 'utf-8', env }).trim();
+  let out = '';
+  try {
+    out = execFileSync('node', args, { encoding: 'utf-8', env }).trim();
+  } catch (err) {
+    const stdout = err?.stdout ? String(err.stdout).trim() : '';
+    const stderr = err?.stderr ? String(err.stderr).trim() : '';
+    const message = err?.message ? String(err.message) : String(err);
+    const detail = redactKnownSecrets([stdout, stderr, message].filter(Boolean).join('\n'));
+    throw new Error(`notionctl api execution failed. ${authSetupHint()}${detail ? `\n${detail}` : ''}`);
+  }
   const obj = out ? JSON.parse(out) : {};
-  if (!obj.ok) throw new Error(`notionctl api not ok: ${out}`);
+  if (!obj.ok) throw new Error(`notionctl api not ok. ${authSetupHint()}\n${redactKnownSecrets(out)}`);
   return obj.result || {};
 }
 

--- a/soul-in-sapphire/README.md
+++ b/soul-in-sapphire/README.md
@@ -161,13 +161,29 @@ pnpm dlx clawhub@latest install notion-api-automation
 3. 親ページ(例: OpenClawページ)をIntegrationに共有(Connect to)
 
 ### 2) APIキー
-推奨: 環境変数
+従来どおり環境変数で渡せます。
 
 ```bash
 export NOTION_API_KEY="..."
 ```
 
-(OpenClaw運用なら `~/.openclaw/.env` に `NOTION_API_KEY=...`)
+OpenClaw運用では `skills.entries["soul-in-sapphire"].apiKey` も使えます。
+`apiKey` はこのskillの `primaryEnv` である `NOTION_API_KEY` として実行時に注入されます。
+SecretRef provider はユーザー環境ごとに異なるため、このskillには特定のvault/item/pathを固定しません。
+
+```json5
+{
+  skills: {
+    entries: {
+      "soul-in-sapphire": {
+        apiKey: { source: "exec", provider: "your_notion_secret_provider", id: "value" }
+      }
+    }
+  }
+}
+```
+
+`source` は `env` / `file` / `exec` など、OpenClaw Gatewayで設定済みのSecretRef providerに合わせてください。
 
 ### 3) DB作成 + config生成
 

--- a/soul-in-sapphire/SKILL.md
+++ b/soul-in-sapphire/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: soul-in-sapphire
 description: "Continuity, durable memory, state tracking, journal writes, identity diffs, and mood/current-state checks for Valentina/OpenClaw. Use for memory writes/search, emotion/state ticks, heartbeat state upkeep, journal synthesis, and preserving self-state across sessions."
-metadata: {"openclaw":{"emoji":"💠","requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"optionalEnv":["NOTIONCTL_PATH"]}}
+metadata: {"openclaw":{"emoji":"💠","requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"optionalEnv":["NOTION_TOKEN","NOTION_API_TOKEN","NOTIONCTL_PATH"]}}
 ---
 
 # soul-in-sapphire
@@ -72,6 +72,28 @@ If uncertain, write to daily memory first. Current user message overrides `USER.
 ## Database IDs
 
 Read TOOLS.md section Soul-in-Sapphire Notion Databases and pass explicit IDs to scripts. Notion API version: 2025-09-03.
+
+## Notion Auth
+
+Provide Notion auth through `NOTION_API_KEY` / `NOTION_TOKEN`, or configure
+`skills.entries["soul-in-sapphire"].apiKey` in OpenClaw. The `apiKey` field is
+associated with this skill's `primaryEnv` and is injected as `NOTION_API_KEY`
+for the host agent run. It may be a plaintext value or any OpenClaw SecretRef
+supported by the local gateway (`env`, `file`, `exec`, etc.).
+
+Do not hardcode provider-specific secret paths in this shared skill. Example:
+
+```json5
+{
+  skills: {
+    entries: {
+      "soul-in-sapphire": {
+        apiKey: { source: "exec", provider: "your_notion_secret_provider", id: "value" }
+      }
+    }
+  }
+}
+```
 
 ## Commands
 

--- a/soul-in-sapphire/references/full-pre-prune-2026-05-27.md
+++ b/soul-in-sapphire/references/full-pre-prune-2026-05-27.md
@@ -1,7 +1,7 @@
 ---
 name: soul-in-sapphire
 description: Long-term memory, state tracking, continuity review, and identity-change support for OpenClaw. Use for durable memory writes/search in Notion, emotion/state ticks, journal writes, continuity checks, identity diffs, inner-conflict tracking, and preserving a stable sense of self across sessions.
-metadata: {"openclaw":{"emoji":"💠","requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"optionalEnv":["NOTIONCTL_PATH"]}}
+metadata: {"openclaw":{"emoji":"💠","requires":{"bins":["node"],"env":["NOTION_API_KEY"]},"primaryEnv":"NOTION_API_KEY","dependsOnSkills":["notion-api-automation"],"optionalEnv":["NOTION_TOKEN","NOTION_API_TOKEN","NOTIONCTL_PATH"]}}
 ---
 
 # soul-in-sapphire (Notion LTM + continuity)
@@ -37,7 +37,10 @@ Install the required dependency skill via ClawHub before using this skill:
 clawhub install notion-api-automation
 ```
 
-- Notion token: `NOTION_API_KEY` (or `NOTION_TOKEN`)
+- Notion token: `NOTION_API_KEY` (or `NOTION_TOKEN` / `NOTION_API_TOKEN`)
+- OpenClaw config may also provide `skills.entries["soul-in-sapphire"].apiKey`.
+  This is injected as `NOTION_API_KEY` through `metadata.openclaw.primaryEnv`
+  and may use any local SecretRef provider (`env`, `file`, `exec`, etc.).
 - Notion API version: `2025-09-03`
 - Dependency skill: `notion-api-automation` (`scripts/notionctl.mjs` is executed via local child process)
 - Optional override: `NOTIONCTL_PATH` (if set, uses explicit notionctl path instead of default sibling skill path)

--- a/soul-in-sapphire/scripts/notionctl_bridge.js
+++ b/soul-in-sapphire/scripts/notionctl_bridge.js
@@ -5,6 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const NOTION_AUTH_ENV_KEYS = ['NOTION_API_KEY', 'NOTION_TOKEN', 'NOTION_API_TOKEN'];
+
 function expandHome(p) {
   if (!p) return p;
   if (p === '~') return os.homedir();
@@ -39,6 +41,24 @@ function apiCompatibilityHint(rawText) {
   return 'Installed notionctl does not support "api". Update skills/notion-api-automation/scripts/notionctl.mjs or set NOTIONCTL_PATH to a compatible notionctl.';
 }
 
+function authSetupHint() {
+  return [
+    'Configure Notion auth with NOTION_API_KEY/NOTION_TOKEN,',
+    'or set skills.entries["soul-in-sapphire"].apiKey to an OpenClaw SecretRef.',
+    'The SecretRef provider can be env, file, exec, or another OpenClaw-supported secure provider.',
+  ].join(' ');
+}
+
+function redactKnownSecrets(text) {
+  let out = String(text || '');
+  for (const k of NOTION_AUTH_ENV_KEYS) {
+    const value = process.env[k];
+    if (!value) continue;
+    out = out.split(String(value)).join(`[redacted:${k}]`);
+  }
+  return out;
+}
+
 function extractExecFailure(err) {
   const stdout = err?.stdout ? String(err.stdout).trim() : '';
   const stderr = err?.stderr ? String(err.stderr).trim() : '';
@@ -65,7 +85,7 @@ function runApi(method, apiPath, body = null) {
     const combined = [info.stdout, info.stderr, info.msg].filter(Boolean).join('\n');
     const compat = apiCompatibilityHint(combined);
     if (compat) throw new Error(compat);
-    throw new Error(`notionctl api execution failed: ${combined || 'unknown error'}`);
+    throw new Error(`notionctl api execution failed. ${authSetupHint()}\n${redactKnownSecrets(combined || 'unknown error')}`);
   }
 
   const obj = parseNotionctlJson(out);
@@ -75,7 +95,7 @@ function runApi(method, apiPath, body = null) {
   if (!obj.ok) {
     const compat = apiCompatibilityHint(out);
     if (compat) throw new Error(compat);
-    throw new Error(`notionctl api not ok: ${out}`);
+    throw new Error(`notionctl api not ok. ${authSetupHint()}\n${redactKnownSecrets(out)}`);
   }
   return obj.result || {};
 }


### PR DESCRIPTION
Closes #8

## Summary
- keep legacy `NOTION_API_KEY` / `NOTION_TOKEN` env auth while documenting OpenClaw `skills.entries.<skill>.apiKey` SecretRef injection
- pass Notion auth envs and `NOTIONCTL_PATH` through `diy-pc-ingest` child `notionctl` calls
- improve Notion auth failure hints without hardcoding provider-specific secret paths

## Verification
- `node --check diy-pc-ingest/scripts/notion_apply_records.js`
- `node --check soul-in-sapphire/scripts/notionctl_bridge.js`
- metadata JSON parse check for updated `SKILL.md` files
- checked no shared skill docs contain 1Password-specific Notion item names or `op://` paths