### PR TITLE
Implement Soul in Sapphire ambient recall staging

### DIFF
--- a/docs/adr/0001-soul-in-sapphire-ambient-recall-dice.md
+++ b/docs/adr/0001-soul-in-sapphire-ambient-recall-dice.md
@@ -1,7 +1,7 @@
 # ADR 0001: Soul in Sapphire の ambient recall dice と workspace staging
 
 - **日付**: 2026-06-05
-- **ステータス**: Proposed
+- **ステータス**: Accepted
 - **対象**: `soul-in-sapphire` skill、recall scripts、OpenClaw workspace memory、cron integration
 - **関連 Issue / PR**: #7
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,7 +4,7 @@ Openclaw-Skills の重要な設計判断を記録するドキュメント群。
 
 | ADR | タイトル | 日付 | ステータス |
 |-----|---------|------|-----------|
-| [0001](0001-soul-in-sapphire-ambient-recall-dice.md) | Soul in Sapphire の ambient recall dice と workspace staging | 2026-06-05 | Proposed |
+| [0001](0001-soul-in-sapphire-ambient-recall-dice.md) | Soul in Sapphire の ambient recall dice と workspace staging | 2026-06-05 | Accepted |
 
 ## ADR テンプレート
 

--- a/soul-in-sapphire/README.md
+++ b/soul-in-sapphire/README.md
@@ -258,10 +258,68 @@ echo '{
 }' | node skills/soul-in-sapphire/scripts/journal_write.js
 ```
 
+### Ambient recall: サイコロで1件stageする
+
+`stage_ambient_recall.js` は cron/script 側でだけサイコロを振り、当たった場合に agent workspace の memory 配下へ短い recall を最大1件だけstageします。会話側やheartbeat側では reroll せず、TTL内の staged recall があれば静かな作業コンテキストとして読むだけにします。
+
+runtime state は skill repo ではなく agent workspace に置きます。
+
+```text
+<OpenClaw workspace>/
+  memory/
+    soul-in-sapphire/
+      ambient-recall.json
+      ambient-recall-state.json
+```
+
+手動実行例:
+
+```bash
+node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
+  --workspace ~/.openclaw/workspace/val \
+  --ttl-minutes 120 \
+  --daily-cap 10
+```
+
+Notion-backed shelf も使う場合は、必要な data source / database IDs を渡します。
+
+```bash
+node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
+  --workspace ~/.openclaw/workspace/val \
+  --state-dsid <STATE_DS_ID> \
+  --journal-dsid <JOURNAL_DS_ID> \
+  --mem-dsid <MEM_DS_ID> \
+  --mem-dbid <MEM_DB_ID>
+```
+
+OpenClaw cron からは20分ごとに上記scriptを呼ぶ運用を想定しています。SecretRef / env 経由で `NOTION_API_KEY` が注入されていれば、Notionを読む棚も使えます。`--workspace` は対象agent/personaのworkspaceを指してください。
+
+サイコロの初期仕様:
+
+```text
+01-03: recent state / journal
+04: unresolved theme
+05: durable memory random
+06: OpenClaw dream
+07-100: none
+```
+
+Dream shelf は OpenClaw workspace の `DREAMS.md` と `memory/dreaming/{rem,light}` を読むだけです。`openclaw memory promote --apply` などの昇格系CLIは呼びません。
+
+検証用:
+
+```bash
+node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
+  --workspace /tmp/sis-ambient-test \
+  --force-roll 6 \
+  --dry-run
+```
+
 ## 自動実行(推奨)
 
 - **01:00 JST**: journalを必ず書く(ニュース1-2件+感想、作業/会話まとめ、未来)
 - **heartbeat**: ファジーに感情が動いた時だけ emostate tick を打つ(通知は必要時のみ)
+- **20分ごと**: `stage_ambient_recall.js` で ambient recall をstageする
 
 OpenClawの cron/heartbeat は環境ごとに設定してください。
 

--- a/soul-in-sapphire/SKILL.md
+++ b/soul-in-sapphire/SKILL.md
@@ -16,6 +16,7 @@ Heartbeat/current-state maintenance:
 3. Write a state snapshot with `scripts/emostate_tick.js` when meaningful.
 4. Update `memory/now-state.json` mirror with mood, intent, stress, updated_at, source, note.
 5. If heartbeat asks for evolution note, append a short daily note after the state write.
+6. If `memory/soul-in-sapphire/ambient-recall.json` exists in the agent workspace and is not expired, read it as quiet context only. Do not reroll here and do not announce it unless it naturally matters.
 
 Mood/check-in:
 - Read `memory/now-state.json` first.
@@ -109,8 +110,12 @@ Emotion/state tick:
 Journal:
     echo '{"body":"...","source":"manual"}' | node skills/soul-in-sapphire/scripts/journal_write.js --journal-dbid <JOURNAL_DB_ID> --journal-dsid <JOURNAL_DS_ID>
 
+Ambient recall stage:
+    node skills/soul-in-sapphire/scripts/stage_ambient_recall.js --workspace <OPENCLAW_WORKSPACE> --state-dsid <STATE_DS_ID> --journal-dsid <JOURNAL_DS_ID> --mem-dsid <MEM_DS_ID> --mem-dbid <MEM_DB_ID>
+
 Continuity helpers:
 - `state_recall.js`: pull recent state snapshots.
+- `stage_ambient_recall.js`: cron-side ambient recall dice and workspace staging.
 - `continuity_check.js`: distinguish stable traits from temporary drift.
 - `identity_diff.js`: compare current vs proposed identity text.
 - `conflict_track.js`: log unresolved tension before changing identity.
@@ -120,6 +125,7 @@ Continuity helpers:
 - Use `emostate_tick.js` when a real event changes mood, intent, stress, or need.
 - Use `journal_write.js` when the day needs synthesis, not just logging.
 - Search durable memory with `ltm_search.js` before guessing past decisions.
+- Treat ambient recall as internal context injection, not a user-visible recall log. The script stages at most one short item under workspace `memory/soul-in-sapphire/`; conversation and heartbeat paths only read unexpired staged recall and never reroll.
 - Draft proposed identity/profile text separately before editing core files.
 - Prefer `identity_diff.js` before any self-description update so the change stays inspectable.
 

--- a/soul-in-sapphire/scripts/stage_ambient_recall.js
+++ b/soul-in-sapphire/scripts/stage_ambient_recall.js
@@ -1,0 +1,460 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { queryDataSource, queryRecent, requireIds, textOf } from './notionctl_bridge.js';
+
+const DEFAULT_STATE_DIR = 'memory/soul-in-sapphire';
+const DEFAULT_TTL_MINUTES = 120;
+const DEFAULT_DAILY_CAP = 10;
+const TITLE_LIMIT = 80;
+const CONTENT_LIMIT = 800;
+const MARKERS = ['unresolved', 'todo', 'tension'];
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function expandHome(p) {
+  if (!p) return p;
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+function parseNumber(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function parseArgs(argv) {
+  const out = {
+    workspace: process.env.OPENCLAW_WORKSPACE || process.cwd(),
+    stateDir: process.env.SIS_AMBIENT_STATE_DIR || DEFAULT_STATE_DIR,
+    ttlMinutes: DEFAULT_TTL_MINUTES,
+    dailyCap: DEFAULT_DAILY_CAP,
+    stateDsid: '',
+    journalDsid: '',
+    memDsid: '',
+    memDbid: '',
+    forceRoll: null,
+    dryRun: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--workspace') out.workspace = argv[++i] || out.workspace;
+    else if (a === '--state-dir') out.stateDir = argv[++i] || out.stateDir;
+    else if (a === '--ttl-minutes') out.ttlMinutes = parseNumber(argv[++i], out.ttlMinutes);
+    else if (a === '--daily-cap') out.dailyCap = parseNumber(argv[++i], out.dailyCap);
+    else if (a === '--state-dsid') out.stateDsid = argv[++i] || '';
+    else if (a === '--journal-dsid') out.journalDsid = argv[++i] || '';
+    else if (a === '--mem-dsid') out.memDsid = argv[++i] || '';
+    else if (a === '--mem-dbid') out.memDbid = argv[++i] || '';
+    else if (a === '--force-roll') out.forceRoll = parseNumber(argv[++i], null);
+    else if (a === '--dry-run') out.dryRun = true;
+  }
+
+  out.workspace = path.resolve(expandHome(out.workspace));
+  out.stateDir = expandHome(out.stateDir);
+  if (!path.isAbsolute(out.stateDir)) out.stateDir = path.join(out.workspace, out.stateDir);
+  out.stateDir = path.resolve(out.stateDir);
+  out.ttlMinutes = Math.max(1, Math.floor(out.ttlMinutes));
+  out.dailyCap = Math.max(0, Math.floor(out.dailyCap));
+  if (out.forceRoll !== null) {
+    out.forceRoll = Math.max(1, Math.min(100, Math.floor(out.forceRoll)));
+  }
+  return out;
+}
+
+function defaultState(date, dailyCap) {
+  return {
+    version: 1,
+    date,
+    rollsToday: 0,
+    hitsToday: 0,
+    lastRollAt: null,
+    lastHitAt: null,
+    dailyCap,
+    lastError: null,
+  };
+}
+
+function readJsonFile(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+function loadState(file, dailyCap) {
+  const date = todayUtc();
+  let state = defaultState(date, dailyCap);
+  let loadError = null;
+  if (fs.existsSync(file)) {
+    try {
+      const parsed = readJsonFile(file);
+      if (parsed && typeof parsed === 'object' && parsed.version === 1) {
+        state = { ...state, ...parsed, dailyCap };
+      } else {
+        loadError = 'ambient state was invalid; reinitialized';
+      }
+    } catch {
+      loadError = 'ambient state JSON was unreadable; reinitialized';
+    }
+  }
+  if (state.date !== date) {
+    state = {
+      ...state,
+      date,
+      rollsToday: 0,
+      hitsToday: 0,
+      dailyCap,
+      lastError: null,
+    };
+  }
+  state._loadError = loadError;
+  return state;
+}
+
+function atomicWriteJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(value, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmp, file);
+}
+
+function randomRoll() {
+  return crypto.randomInt(1, 101);
+}
+
+function shelfForRoll(roll) {
+  if (roll >= 1 && roll <= 3) return 'recent';
+  if (roll === 4) return 'unresolved';
+  if (roll === 5) return 'durable';
+  if (roll === 6) return 'dream';
+  return null;
+}
+
+function truncateText(value, limit) {
+  const s = String(value || '').replace(/\s+/g, ' ').trim();
+  if (s.length <= limit) return s;
+  return `${s.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+}
+
+function relativePath(workspace, file) {
+  const rel = path.relative(workspace, file);
+  return rel && !rel.startsWith('..') && !path.isAbsolute(rel) ? rel : file;
+}
+
+function candidate(title, content, source) {
+  const t = truncateText(title, TITLE_LIMIT);
+  const c = truncateText(content || title, CONTENT_LIMIT);
+  if (!t && !c) return null;
+  return { title: t || truncateText(c, TITLE_LIMIT), content: c, source };
+}
+
+function markdownText(s) {
+  return String(s || '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/^#+\s*/gm, '')
+    .replace(/^\s*[-*]\s*/gm, '')
+    .replace(/\[[^\]]+\]\([^)]+\)/g, m => m.replace(/\[|\]\([^)]+\)/g, ''))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function newestFiles(dir, suffix = '.md', limit = 10) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter(d => d.isFile() && d.name.endsWith(suffix))
+    .map(d => path.join(dir, d.name))
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, limit);
+}
+
+function readFirstExistingJsonl(files) {
+  for (const file of files) {
+    if (!fs.existsSync(file)) continue;
+    const lines = fs.readFileSync(file, 'utf-8').split(/\r?\n/).filter(Boolean);
+    for (const line of lines.reverse()) {
+      try {
+        const obj = JSON.parse(line);
+        return { file, obj };
+      } catch {
+        // Keep scanning older lines.
+      }
+    }
+  }
+  return null;
+}
+
+function readDreamRem(workspace) {
+  const dir = path.join(workspace, 'memory', 'dreaming', 'rem');
+  for (const file of newestFiles(dir, '.md', 14)) {
+    const raw = fs.readFileSync(file, 'utf-8');
+    const lines = raw.split(/\r?\n/);
+    const picked = lines.find(line => /^-\s+(?!No strong)/i.test(line.trim()));
+    if (picked) {
+      return candidate('REM dream reflection', picked.replace(/^-\s*/, ''), {
+        type: 'openclaw_dream',
+        path: relativePath(workspace, file),
+      });
+    }
+  }
+  return null;
+}
+
+function readDreamLight(workspace) {
+  const dir = path.join(workspace, 'memory', 'dreaming', 'light');
+  for (const file of newestFiles(dir, '.md', 14)) {
+    const raw = fs.readFileSync(file, 'utf-8');
+    const blocks = raw.split(/\n(?=-\s+Candidate:)/g).filter(s => /^\s*-\s+Candidate:/m.test(s));
+    for (const block of blocks) {
+      if (!/status:\s*staged/i.test(block)) continue;
+      const text = markdownText(block.replace(/^\s*-\s+Candidate:\s*/m, ''));
+      if (text) {
+        return candidate('Light dream candidate', text, {
+          type: 'openclaw_dream',
+          path: relativePath(workspace, file),
+        });
+      }
+    }
+  }
+  return null;
+}
+
+function readDreamDiary(workspace) {
+  const file = path.join(workspace, 'DREAMS.md');
+  if (!fs.existsSync(file)) return null;
+  const raw = fs.readFileSync(file, 'utf-8');
+  const chunks = raw.split(/\n---+\n/g).map(s => markdownText(s)).filter(s => s && s !== 'Dream Diary');
+  const latest = chunks[chunks.length - 1];
+  if (!latest) return null;
+  return candidate('Dream diary', latest, {
+    type: 'openclaw_dream',
+    path: relativePath(workspace, file),
+  });
+}
+
+function readDream(workspace) {
+  return readDreamRem(workspace) || readDreamLight(workspace) || readDreamDiary(workspace);
+}
+
+function readLatestDailyMemory(workspace) {
+  const file = newestFiles(path.join(workspace, 'memory'), '.md', 1)[0];
+  if (!file) return null;
+  const text = markdownText(fs.readFileSync(file, 'utf-8'));
+  if (!text) return null;
+  return candidate('Recent daily memory', text, {
+    type: 'workspace_memory',
+    path: relativePath(workspace, file),
+  });
+}
+
+function readDailyMarker(workspace) {
+  const files = newestFiles(path.join(workspace, 'memory'), '.md', 40);
+  for (const file of files) {
+    const raw = fs.readFileSync(file, 'utf-8');
+    const lines = raw.split(/\r?\n/);
+    const line = lines.find(l => MARKERS.some(m => l.toLowerCase().includes(m)));
+    if (!line) continue;
+    return candidate('Unresolved memory marker', line, {
+      type: 'workspace_memory',
+      path: relativePath(workspace, file),
+    });
+  }
+  return null;
+}
+
+function readUnresolved(workspace) {
+  const hit = readFirstExistingJsonl([
+    path.join(workspace, 'memory', 'soul-in-sapphire', 'conflicts.jsonl'),
+    path.join(workspace, 'memory', 'conflicts.jsonl'),
+    path.join(workspace, 'soul-in-sapphire', 'state', 'conflicts.jsonl'),
+  ]);
+  if (hit) {
+    const r = hit.obj;
+    const content = [
+      r.tension,
+      r.current_pull ? `current_pull: ${r.current_pull}` : '',
+      r.next_signal ? `next_signal: ${r.next_signal}` : '',
+      r.note,
+    ].filter(Boolean).join(' ');
+    const title = r.tension || 'Unresolved tension';
+    return candidate(title, content, {
+      type: 'local_conflict',
+      path: relativePath(workspace, hit.file),
+    });
+  }
+  return readDailyMarker(workspace);
+}
+
+function normalizeStatePage(page) {
+  const p = page?.properties || {};
+  const title = textOf(p.reason) || textOf(p.Name) || textOf(p.when) || 'Recent state';
+  const parts = [
+    textOf(p.when),
+    textOf(p.mood_label),
+    textOf(p.intent),
+    textOf(p.need_stack),
+    textOf(p.reason),
+  ].flat().filter(Boolean).join(' ');
+  return candidate(title, parts, {
+    type: 'notion_state',
+    id: page?.id,
+    url: page?.url,
+  });
+}
+
+function normalizeJournalPage(page) {
+  const p = page?.properties || {};
+  const title = textOf(p.Name) || textOf(p.when) || 'Recent journal';
+  const parts = [
+    textOf(p.when),
+    textOf(p.body),
+    textOf(p.worklog),
+    textOf(p.future),
+  ].flat().filter(Boolean).join(' ');
+  return candidate(title, parts, {
+    type: 'notion_journal',
+    id: page?.id,
+    url: page?.url,
+  });
+}
+
+function readRecent(args) {
+  if (args.stateDsid) {
+    const pages = queryRecent(args.stateDsid, 1);
+    if (pages[0]) return normalizeStatePage(pages[0]);
+  }
+  if (args.journalDsid) {
+    const pages = queryRecent(args.journalDsid, 1);
+    if (pages[0]) return normalizeJournalPage(pages[0]);
+  }
+  return readLatestDailyMemory(args.workspace);
+}
+
+function readDurable(args) {
+  const cfg = { data_source_id: args.memDsid, database_id: args.memDbid };
+  requireIds(cfg);
+  const res = queryDataSource(args.memDsid, {
+    page_size: 25,
+    sorts: [{ timestamp: 'created_time', direction: 'descending' }],
+  });
+  const pages = res?.results || [];
+  if (!pages.length) return null;
+  const page = pages[crypto.randomInt(0, pages.length)];
+  const p = page?.properties || {};
+  return candidate(textOf(p.Name) || 'Durable memory', textOf(p.Content), {
+    type: 'notion_memory',
+    id: page?.id,
+    url: page?.url,
+  });
+}
+
+function readShelf(shelf, args) {
+  if (shelf === 'recent') return readRecent(args);
+  if (shelf === 'unresolved') return readUnresolved(args.workspace);
+  if (shelf === 'durable') return readDurable(args);
+  if (shelf === 'dream') return readDream(args.workspace);
+  return null;
+}
+
+function buildStaged(candidateObj, shelf, roll, args, at) {
+  const expires = new Date(new Date(at).getTime() + args.ttlMinutes * 60 * 1000).toISOString();
+  return {
+    version: 1,
+    kind: 'ambient_recall',
+    shelf,
+    staged_at: at,
+    expires_at: expires,
+    roll,
+    title: truncateText(candidateObj.title, TITLE_LIMIT),
+    content: truncateText(candidateObj.content, CONTENT_LIMIT),
+    source: candidateObj.source || { type: shelf },
+  };
+}
+
+function cleanExpired(stagedFile) {
+  if (!fs.existsSync(stagedFile)) return false;
+  try {
+    const obj = readJsonFile(stagedFile);
+    if (obj?.expires_at && new Date(obj.expires_at).getTime() < Date.now()) {
+      fs.unlinkSync(stagedFile);
+      return true;
+    }
+  } catch {
+    fs.unlinkSync(stagedFile);
+    return true;
+  }
+  return false;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const stateFile = path.join(args.stateDir, 'ambient-recall-state.json');
+  const stagedFile = path.join(args.stateDir, 'ambient-recall.json');
+  const at = nowIso();
+  let state = loadState(stateFile, args.dailyCap);
+  const loadError = state._loadError;
+  delete state._loadError;
+  const roll = args.forceRoll ?? randomRoll();
+  const shelf = shelfForRoll(roll);
+  let staged = null;
+  let cleanedExpired = false;
+
+  state.rollsToday = Number(state.rollsToday || 0) + 1;
+  state.lastRollAt = at;
+  state.dailyCap = args.dailyCap;
+  state.lastError = loadError || null;
+
+  try {
+    if (state.hitsToday >= args.dailyCap && shelf) {
+      state.lastError = `dailyCap reached (${args.dailyCap}); skipped ${shelf}`;
+    } else if (shelf) {
+      const c = readShelf(shelf, args);
+      if (c) {
+        staged = buildStaged(c, shelf, roll, args, at);
+        state.hitsToday = Number(state.hitsToday || 0) + 1;
+        state.lastHitAt = at;
+      } else {
+        state.lastError = `no ambient candidate for shelf: ${shelf}`;
+      }
+    } else if (!args.dryRun) {
+      cleanedExpired = cleanExpired(stagedFile);
+    }
+  } catch (err) {
+    state.lastError = truncateText(err?.message || String(err), 240);
+  }
+
+  if (!args.dryRun) {
+    fs.mkdirSync(args.stateDir, { recursive: true });
+    atomicWriteJson(stateFile, state);
+    if (staged) atomicWriteJson(stagedFile, staged);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    dryRun: args.dryRun,
+    roll,
+    shelf,
+    staged: !!staged,
+    cleanedExpired,
+    stateFile,
+    stagedFile,
+    lastError: state.lastError,
+    recall: staged,
+  }, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(String(err?.stack || err));
+  process.exit(1);
+}

--- a/soul-in-sapphire/scripts/stage_ambient_recall.js
+++ b/soul-in-sapphire/scripts/stage_ambient_recall.js
@@ -339,10 +339,10 @@ function readRecent(args) {
   return readLatestDailyMemory(args.workspace);
 }
 
-function readDurable(args) {
+async function readDurable(args) {
   const cfg = { data_source_id: args.memDsid, database_id: args.memDbid };
   requireIds(cfg);
-  const res = queryDataSource(args.memDsid, {
+  const res = await queryDataSource(args.memDsid, {
     page_size: 25,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
   });
@@ -357,10 +357,10 @@ function readDurable(args) {
   });
 }
 
-function readShelf(shelf, args) {
+async function readShelf(shelf, args) {
   if (shelf === 'recent') return readRecent(args);
   if (shelf === 'unresolved') return readUnresolved(args.workspace);
-  if (shelf === 'durable') return readDurable(args);
+  if (shelf === 'durable') return await readDurable(args);
   if (shelf === 'dream') return readDream(args.workspace);
   return null;
 }
@@ -395,7 +395,7 @@ function cleanExpired(stagedFile) {
   return false;
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv);
   const stateFile = path.join(args.stateDir, 'ambient-recall-state.json');
   const stagedFile = path.join(args.stateDir, 'ambient-recall.json');
@@ -417,7 +417,7 @@ function main() {
     if (state.hitsToday >= args.dailyCap && shelf) {
       state.lastError = `dailyCap reached (${args.dailyCap}); skipped ${shelf}`;
     } else if (shelf) {
-      const c = readShelf(shelf, args);
+      const c = await readShelf(shelf, args);
       if (c) {
         staged = buildStaged(c, shelf, roll, args, at);
         state.hitsToday = Number(state.hitsToday || 0) + 1;
@@ -453,7 +453,7 @@ function main() {
 }
 
 try {
-  main();
+  await main();
 } catch (err) {
   console.error(String(err?.stack || err));
   process.exit(1);


### PR DESCRIPTION
Closes #7

## Summary

- Add `stage_ambient_recall.js` for cron-side ambient recall dice and workspace staging
- Store runtime state under the agent workspace `memory/soul-in-sapphire/`, not in the skill repo
- Add forced-roll/dry-run support for deterministic verification
- Document ambient recall behavior in `SKILL.md`, `README.md`, and mark ADR 0001 Accepted

## Behavior

- Roll `1d100`; `01-03` recent, `04` unresolved, `05` durable, `06` dream, otherwise no stage
- Stage at most one short recall item with TTL and atomic JSON write
- Conversation/heartbeat paths read unexpired staged recall only and do not reroll
- Dream shelf reads OpenClaw workspace artifacts only; it does not call memory promotion commands

## Verification

- `node --check soul-in-sapphire/scripts/stage_ambient_recall.js`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-test --force-roll 1 --dry-run`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-test --force-roll 4 --dry-run`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-test --force-roll 5 --dry-run`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-test --force-roll 6 --dry-run`
- invalid state JSON reinitialization verified in `/tmp/sis-ambient-test`
- expired staged recall cleanup verified in `/tmp/sis-ambient-test`
- `git diff --check`
