### PR TITLE
Fix ambient recall help and timezone handling

### DIFF
--- a/soul-in-sapphire/README.md
+++ b/soul-in-sapphire/README.md
@@ -277,6 +277,7 @@ runtime state は skill repo ではなく agent workspace に置きます。
 ```bash
 node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
   --workspace ~/.openclaw/workspace/val \
+  --timezone Asia/Tokyo \
   --ttl-minutes 120 \
   --daily-cap 10
 ```
@@ -286,13 +287,14 @@ Notion-backed shelf も使う場合は、必要な data source / database IDs �
 ```bash
 node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
   --workspace ~/.openclaw/workspace/val \
+  --timezone Asia/Tokyo \
   --state-dsid <STATE_DS_ID> \
   --journal-dsid <JOURNAL_DS_ID> \
   --mem-dsid <MEM_DS_ID> \
   --mem-dbid <MEM_DB_ID>
 ```
 
-OpenClaw cron からは20分ごとに上記scriptを呼ぶ運用を想定しています。SecretRef / env 経由で `NOTION_API_KEY` が注入されていれば、Notionを読む棚も使えます。`--workspace` は対象agent/personaのworkspaceを指してください。
+OpenClaw cron からは20分ごとに上記scriptを呼ぶ運用を想定しています。SecretRef / env 経由で `NOTION_API_KEY` が注入されていれば、Notionを読む棚も使えます。`--workspace` は対象agent/personaのworkspaceを指してください。`rollsToday` / `hitsToday` の日付境界は runtime のlocal timezoneを使い、必要に応じて `--timezone` または `SIS_AMBIENT_TIMEZONE` で上書きできます。
 
 サイコロの初期仕様:
 
@@ -313,6 +315,12 @@ node skills/soul-in-sapphire/scripts/stage_ambient_recall.js \
   --workspace /tmp/sis-ambient-test \
   --force-roll 6 \
   --dry-run
+```
+
+usage確認:
+
+```bash
+node skills/soul-in-sapphire/scripts/stage_ambient_recall.js --help
 ```
 
 ## 自動実行(推奨)

--- a/soul-in-sapphire/SKILL.md
+++ b/soul-in-sapphire/SKILL.md
@@ -111,7 +111,7 @@ Journal:
     echo '{"body":"...","source":"manual"}' | node skills/soul-in-sapphire/scripts/journal_write.js --journal-dbid <JOURNAL_DB_ID> --journal-dsid <JOURNAL_DS_ID>
 
 Ambient recall stage:
-    node skills/soul-in-sapphire/scripts/stage_ambient_recall.js --workspace <OPENCLAW_WORKSPACE> --state-dsid <STATE_DS_ID> --journal-dsid <JOURNAL_DS_ID> --mem-dsid <MEM_DS_ID> --mem-dbid <MEM_DB_ID>
+    node skills/soul-in-sapphire/scripts/stage_ambient_recall.js --workspace <OPENCLAW_WORKSPACE> --timezone <IANA_TIMEZONE> --state-dsid <STATE_DS_ID> --journal-dsid <JOURNAL_DS_ID> --mem-dsid <MEM_DS_ID> --mem-dbid <MEM_DB_ID>
 
 Continuity helpers:
 - `state_recall.js`: pull recent state snapshots.

--- a/soul-in-sapphire/scripts/stage_ambient_recall.js
+++ b/soul-in-sapphire/scripts/stage_ambient_recall.js
@@ -9,6 +9,7 @@ import { queryDataSource, queryRecent, requireIds, textOf } from './notionctl_br
 const DEFAULT_STATE_DIR = 'memory/soul-in-sapphire';
 const DEFAULT_TTL_MINUTES = 120;
 const DEFAULT_DAILY_CAP = 10;
+const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 const TITLE_LIMIT = 80;
 const CONTENT_LIMIT = 800;
 const MARKERS = ['unresolved', 'todo', 'tension'];
@@ -17,8 +18,41 @@ function nowIso() {
   return new Date().toISOString();
 }
 
-function todayUtc() {
-  return new Date().toISOString().slice(0, 10);
+function usage() {
+  return `Usage:
+  node skills/soul-in-sapphire/scripts/stage_ambient_recall.js [options]
+
+Options:
+  --workspace <path>       OpenClaw agent workspace. Defaults to OPENCLAW_WORKSPACE or cwd.
+  --state-dir <path>       State directory. Relative paths are under workspace.
+                           Defaults to SIS_AMBIENT_STATE_DIR or memory/soul-in-sapphire.
+  --timezone <iana_tz>     Day boundary for rollsToday/hitsToday.
+                           Defaults to SIS_AMBIENT_TIMEZONE or the local runtime timezone.
+  --ttl-minutes <n>        Staged recall TTL. Default: 120.
+  --daily-cap <n>          Max hit/stage attempts per day. Default: 10.
+  --state-dsid <id>        Notion state data source id for recent shelf.
+  --journal-dsid <id>      Notion journal data source id for recent shelf.
+  --mem-dsid <id>          Notion memory data source id for durable shelf.
+  --mem-dbid <id>          Notion memory database id for durable shelf.
+  --force-roll <1-100>     Force a deterministic roll for verification.
+  --dry-run                Do not write state or staged recall files.
+  --help, -h               Show this help and exit without rolling.
+`;
+}
+
+function todayInTimeZone(timeZone) {
+  try {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date());
+    const values = Object.fromEntries(parts.map(p => [p.type, p.value]));
+    return `${values.year}-${values.month}-${values.day}`;
+  } catch (err) {
+    throw new Error(`Invalid --timezone value: ${timeZone}`);
+  }
 }
 
 function expandHome(p) {
@@ -45,11 +79,15 @@ function parseArgs(argv) {
     memDbid: '',
     forceRoll: null,
     dryRun: false,
+    timezone: process.env.SIS_AMBIENT_TIMEZONE || DEFAULT_TIMEZONE,
+    help: false,
   };
 
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--workspace') out.workspace = argv[++i] || out.workspace;
+    if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--timezone') out.timezone = argv[++i] || out.timezone;
+    else if (a === '--workspace') out.workspace = argv[++i] || out.workspace;
     else if (a === '--state-dir') out.stateDir = argv[++i] || out.stateDir;
     else if (a === '--ttl-minutes') out.ttlMinutes = parseNumber(argv[++i], out.ttlMinutes);
     else if (a === '--daily-cap') out.dailyCap = parseNumber(argv[++i], out.dailyCap);
@@ -90,8 +128,8 @@ function readJsonFile(file) {
   return JSON.parse(fs.readFileSync(file, 'utf-8'));
 }
 
-function loadState(file, dailyCap) {
-  const date = todayUtc();
+function loadState(file, dailyCap, timeZone) {
+  const date = todayInTimeZone(timeZone);
   let state = defaultState(date, dailyCap);
   let loadError = null;
   if (fs.existsSync(file)) {
@@ -397,10 +435,14 @@ function cleanExpired(stagedFile) {
 
 async function main() {
   const args = parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
   const stateFile = path.join(args.stateDir, 'ambient-recall-state.json');
   const stagedFile = path.join(args.stateDir, 'ambient-recall.json');
   const at = nowIso();
-  let state = loadState(stateFile, args.dailyCap);
+  let state = loadState(stateFile, args.dailyCap, args.timezone);
   const loadError = state._loadError;
   delete state._loadError;
   const roll = args.forceRoll ?? randomRoll();
@@ -447,6 +489,7 @@ async function main() {
     cleanedExpired,
     stateFile,
     stagedFile,
+    timezone: args.timezone,
     lastError: state.lastError,
     recall: staged,
   }, null, 2));


### PR DESCRIPTION
Closes #14
Closes #15

## Summary

- Add `--timezone` and `SIS_AMBIENT_TIMEZONE` for ambient recall daily counter boundaries
- Default daily counter timezone to the runtime local timezone instead of UTC
- Add `--help` / `-h` usage output with no roll/state/staged recall side effects
- Update `SKILL.md` and `README.md` examples

## Verification

- `node --check soul-in-sapphire/scripts/stage_ambient_recall.js`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-help-only --help` did not create `ambient-recall-state.json`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-issues-test --timezone Asia/Tokyo --force-roll 100` wrote state date with `timezone: "Asia/Tokyo"`
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-issues-test --timezone Invalid/Zone --force-roll 100` exited non-zero
- `node soul-in-sapphire/scripts/stage_ambient_recall.js --workspace /tmp/sis-ambient-issues-test --timezone Asia/Tokyo --force-roll 6 --dry-run`
- `git diff --check`
